### PR TITLE
Cache for a*

### DIFF
--- a/src/model/map/a_star.py
+++ b/src/model/map/a_star.py
@@ -74,19 +74,19 @@ def a_star_search(kd_map, start_node_id: str, goal_node_id: str, cache_dict: Dic
 
         # Checking for cache
 
-        # t = get_ordered_tuple(current, goal_node_id)
-        # if t in cache_dict:
-        #     #print("found in cache")
-        #     cached_path = cache_dict[t]
-        #     if cached_path[0] == goal_node_id:
-        #         cached_path.reverse()
+        t = get_ordered_tuple(current, goal_node_id)
+        if t in cache_dict:
+            #print("found in cache")
+            cached_path = cache_dict[t]
+            if cached_path[0] == goal_node_id:
+                cached_path.reverse()
             
-        #     path = reconstruct_path(came_from, start_node_id, current)
-        #     path = path + cached_path[1:]
+            path = reconstruct_path(came_from, start_node_id, current)
+            path = path + cached_path[1:]
 
-        #     cache_dict[start_goal_tuple] = path
+            cache_dict[start_goal_tuple] = path
 
-        #     return path
+            return path
 
         current_node = kd_map.d_nodes[current]
         for conn in current_node.connections:
@@ -148,27 +148,33 @@ def parallel_a_star(kd_map, start_goals_arr, n_threads=1, pathfind_cache = {}, r
                                             the value is an array of strings that is the path between the nodes
     """
     response = {}
-    thread_paths = np.array_split(start_goals_arr, n_threads)
+    if n_threads == 1 or len(start_goals_arr) == 1:
+        a_star_thread(0, kd_map, start_goals_arr, report, response, pathfind_cache)
+    else:
+        thread_paths = np.array_split(start_goals_arr, n_threads)
 
-    with Manager() as manager:
-        cache_dict = manager.dict()
-        path_dict = manager.dict()
-        tasks = []
-        for i in range(n_threads):
-            tasks.append((i, kd_map, thread_paths[i], report, path_dict, cache_dict))
-
-        pool = Pool()
-        pool.starmap(a_star_thread, tasks)
-        pool.close()
-
-        if report is not None:
-            print("workers finished, total paths: ", len(path_dict))
-        
-        for k, v in path_dict.items():
-            response[k] = v
+        with Manager() as manager:
+            cache_dict = manager.dict()
+            path_dict = manager.dict()
             
-        # pathfind_cache = cache_dict
-        # for k, v in cache_dict.items():
-        #     pathfind_cache[k] = v
+            for k, v in pathfind_cache.items():
+                cache_dict[k] = v
+
+            tasks = []
+            for i in range(n_threads):
+                tasks.append((i, kd_map, thread_paths[i], report, path_dict, cache_dict))
+
+            pool = Pool()
+            pool.starmap(a_star_thread, tasks)
+            pool.close()
+
+            if report is not None:
+                print("workers finished, total paths: ", len(path_dict))
+            
+            for k, v in path_dict.items():
+                response[k] = v
+                
+            for k, v in cache_dict.items():
+                pathfind_cache[k] = v
 
     return response


### PR DESCRIPTION
- Added caching for a* algorithm
- If the program is configured to run in only one thread or there is one path to be calculated, it does not initiate the multithreading process, saving time in preprocessing.