### PR TITLE
Fix: infection_summary timestamp and agent_position_summary locations

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -197,19 +197,19 @@ class Controller():
         log_data = {}
         health_header = ["time_stamp","susceptible","exposed",
                   "asymptomatic","symptomatic","severe","recovered"]
-        for x in health_header:
-            log_data[x] = summarized_attr[x] if x in summarized_attr.keys() else 0
+        for h in health_header:
+            log_data[h] = summarized_attr[h] if h in summarized_attr.keys() else 0
 
         log_data["time_stamp"] = self.sim.ts.step_count
         self.logger.write_csv_data("infection_summary.csv", log_data)
 
         # agent position
-        temp = self.sim.summarized_attribute("location")
-        for x in temp.keys():
+        summarized_attr = self.sim.summarized_attribute("location")
+        for k in summarized_attr.keys():
             log_data = {}
             log_data["time_stamp"] = self.sim.ts.step_count
-            log_data["location"]   = x
-            log_data["count"]      = temp[x]
+            log_data["location"]   = k
+            log_data["count"]      = summarized_attr[k]
             self.logger.write_csv_data("agent_position_summary.csv", log_data)
 
         ###########################################################################

--- a/controller.py
+++ b/controller.py
@@ -195,7 +195,6 @@ class Controller():
         ########################### LOGGING ###########################################
         temp = self.sim.summarized_attribute("covid")
         temp2 = {}
-        temp2["time_stamp"] = self.sim.ts.step_count
         health_header = ["time_stamp","susceptible","exposed",
                   "asymptomatic","symptomatic","severe","recovered"]
         for x in health_header:
@@ -203,6 +202,7 @@ class Controller():
                 temp2[x] = temp[x]
             else:
                 temp2[x] = 0
+        temp2["time_stamp"] = self.sim.ts.step_count
 
         self.logger.write_csv_data("infection_summary.csv", temp2)
 

--- a/controller.py
+++ b/controller.py
@@ -193,29 +193,24 @@ class Controller():
         # LOGGING
         # infection summary
         ########################### LOGGING ###########################################
-        temp = self.sim.summarized_attribute("covid")
-        temp2 = {}
+        summarized_attr = self.sim.summarized_attribute("covid")
+        log_data = {}
         health_header = ["time_stamp","susceptible","exposed",
                   "asymptomatic","symptomatic","severe","recovered"]
         for x in health_header:
-            if x in temp.keys():
-                temp2[x] = temp[x]
-            else:
-                temp2[x] = 0
-        temp2["time_stamp"] = self.sim.ts.step_count
+            log_data[x] = summarized_attr[x] if x in summarized_attr.keys() else 0
 
-        self.logger.write_csv_data("infection_summary.csv", temp2)
+        log_data["time_stamp"] = self.sim.ts.step_count
+        self.logger.write_csv_data("infection_summary.csv", log_data)
 
         # agent position
         temp = self.sim.summarized_attribute("location")
         for x in temp.keys():
-            temp2 = {}
-            temp2["time_stamp"] = self.sim.ts.step_count
-            temp2["location"]   = x
-            temp2["count"]      = temp[x]
-
-        self.logger.write_csv_data("agent_position_summary.csv", temp2)
-
+            log_data = {}
+            log_data["time_stamp"] = self.sim.ts.step_count
+            log_data["location"]   = x
+            log_data["count"]      = temp[x]
+            self.logger.write_csv_data("agent_position_summary.csv", log_data)
 
         ###########################################################################
         # STEP


### PR DESCRIPTION
Fixed a bug where the time_stamp on infection_summary would not show properly because the assertion to a var was being done too soon.

Fixed a bug in agent_position_summary where only one location would show up each time_stamp.

Changed var names to be more descriptive.