### PR TITLE
Fix get closest evacuation center default value

### DIFF
--- a/src/model/behavioral/activity/action_move.py
+++ b/src/model/behavioral/activity/action_move.py
@@ -34,7 +34,11 @@ class ActionMove(Action):
         if destination_string == "!evac":
             # print(f"agent {self.agent.agent_id}'s' go to evac")
             node = kd_map.d_nodes[self.origin]
-            self.target = kd_map.get_closest_evacuation_center(node.coordinate,agent.get_attribute("explored_evac"))
+            self.target = kd_map.get_closest_evacuation_center(
+                node.coordinate,
+                agent.get_attribute("explored_evac"),
+                agent.get_attribute("home_node_id")
+            )
             agent.set_attribute("target_evac",self.target.centroid)
             self.destination = self.target.centroid
             self.target_type = "Evacuation Point"

--- a/src/model/evacuation/evacuation_module.py
+++ b/src/model/evacuation/evacuation_module.py
@@ -121,12 +121,6 @@ class EvacuationModule(Module):
                         agent.get_attribute("home_node_id")    
                     )
 
-                    # TODO: check what to do if there is not available evacuation palces anymore
-                    if new_target is None:
-                        new_target = agent.get_attribute("home_node_id").lower()
-                    else:
-                        new_target = new_target.centroid
-
                     agent.set_attribute("target_evac", new_target)
                     self.log_ag_refused_evac(
                         ts,

--- a/src/model/evacuation/evacuation_module.py
+++ b/src/model/evacuation/evacuation_module.py
@@ -115,7 +115,11 @@ class EvacuationModule(Module):
 
 
                 else:
-                    new_target = kd_map.get_closest_evacuation_center(agent.coordinate,agent.get_attribute("explored_evac"))
+                    new_target = kd_map.get_closest_evacuation_center(
+                        agent.coordinate,
+                        agent.get_attribute("explored_evac"),
+                        agent.get_attribute("home_node_id")    
+                    )
 
                     # TODO: check what to do if there is not available evacuation palces anymore
                     if new_target is None:

--- a/src/model/map/map.py
+++ b/src/model/map/map.py
@@ -89,6 +89,8 @@ class Map():
             if temp_place.centroid not in explored_places and temp_distance < distance:
                 place = self.d_evacuation_centers[evac_place_id]
                 distance = temp_distance
+
+        # TODO: check what to do if there is not available evacuation palces anymore
         if place == None:
             for p in self.d_places.values():
                 if p.centroid == home_id:

--- a/src/model/map/map.py
+++ b/src/model/map/map.py
@@ -78,10 +78,10 @@ class Map():
         results = rng.choice(arr, qtd, replace=False)
         return results
 
-    def get_closest_evacuation_center(self,coordinate, explored_places):
+    def get_closest_evacuation_center(self,coordinate, explored_places, home_id):
         explored_evac_center = explored_places.split(",")
         distance = sys.float_info.max
-        place = None
+        place = self.d_nodes[home_id]
         for evac_place_id in self.d_evacuation_centers:
             temp_place = self.d_evacuation_centers[evac_place_id]
             node = self.d_nodes[temp_place.centroid]

--- a/src/model/map/map.py
+++ b/src/model/map/map.py
@@ -81,7 +81,7 @@ class Map():
     def get_closest_evacuation_center(self,coordinate, explored_places, home_id):
         explored_evac_center = explored_places.split(",")
         distance = sys.float_info.max
-        place = self.d_nodes[home_id]
+        place = None
         for evac_place_id in self.d_evacuation_centers:
             temp_place = self.d_evacuation_centers[evac_place_id]
             node = self.d_nodes[temp_place.centroid]
@@ -89,6 +89,11 @@ class Map():
             if temp_place.centroid not in explored_places and temp_distance < distance:
                 place = self.d_evacuation_centers[evac_place_id]
                 distance = temp_distance
+        if place == None:
+            for p in self.d_places.values():
+                if p.centroid == home_id:
+                    place = p
+                    break
         return place
 
     def get_random_connected_nodes(self,node_id, last_visited,rng):


### PR DESCRIPTION
A bug happens when calling the function "get_closest_evacuation_center" when the agent has already visited all the evacuation centers and they are full. The function return nulls and this causes errors in other functions.

To fix this, the function now returns a default value if there is no available evacuation center.  For the time being, the default value is the home of the agent. I think this is sensible but not the best solution because if the agent is evacuating their place sometimes is not safe. Nevertheless, I am putting  this as the default location so we can run the simulation and we can discuss what we do next meeting